### PR TITLE
Remove index on large varchar

### DIFF
--- a/sql/derived_tables/req_stats.sql
+++ b/sql/derived_tables/req_stats.sql
@@ -33,5 +33,3 @@ CREATE INDEX ON reshare_derived.req_stats (rs_from_status);
 
 CREATE INDEX ON reshare_derived.req_stats (rs_to_status);
 
-CREATE INDEX ON reshare_derived.req_stats (rs_message);
-


### PR DESCRIPTION
The column contains values too large for a B-tree index.