### PR TITLE
Pinning consortium to top of core results list.

### DIFF
--- a/sql/report_queries/core_requesting/core_req.sql
+++ b/sql/report_queries/core_requesting/core_req.sql
@@ -1,85 +1,98 @@
 -- Switch from FILTER to CASE for RedShift compatibility.
 SELECT
-    rs_requester AS requester,
-    sum(
-        CASE WHEN rs_to_status = 'REQ_VALIDATED' THEN
-            1
-        ELSE
-            0
-        END) AS reqs,
-    sum(
-        CASE WHEN rs_to_status = 'REQ_CANCELLED' THEN
-            1
-        ELSE
-            0
-        END) AS cancelled,
-    sum(
-        CASE WHEN rs_to_status = 'REQ_END_OF_ROTA' THEN
-            1
-        ELSE
-            0
-        END) AS unfilled,
-    sum(
-        CASE WHEN rs_to_status = 'REQ_CHECKED_IN'
-            OR rs_to_status = 'REQ_FILLED_LOCALLY' THEN
-            1
-        ELSE
-            0
-        END) AS received,
-    round((sum(
-            CASE WHEN rs_to_status = 'REQ_CHECKED_IN' THEN
+    *
+FROM (
+    SELECT
+        rs_requester AS requester,
+        sum(
+            CASE WHEN rs_to_status = 'REQ_VALIDATED' THEN
                 1
             ELSE
                 0
-            END) / cast(sum(
-                CASE WHEN rs_to_status = 'REQ_VALIDATED' THEN
-                    1
-                ELSE
-                    0
-                END) AS decimal)), 2) AS filled_ratio
-FROM
-    reshare_derived.req_stats
-GROUP BY
-    requester
-UNION
-SELECT
-    'consortium' AS requester,
-    sum(
-        CASE WHEN rs_to_status = 'REQ_VALIDATED' THEN
-            1
-        ELSE
-            0
-        END) AS reqs,
-    sum(
-        CASE WHEN rs_to_status = 'REQ_CANCELLED' THEN
-            1
-        ELSE
-            0
-        END) AS cancelled,
-    sum(
-        CASE WHEN rs_to_status = 'REQ_END_OF_ROTA' THEN
-            1
-        ELSE
-            0
-        END) AS unfilled,
-    sum(
-        CASE WHEN rs_to_status = 'REQ_CHECKED_IN'
-            OR rs_to_status = 'REQ_FILLED_LOCALLY' THEN
-            1
-        ELSE
-            0
-        END) AS received,
-    round((sum(
-            CASE WHEN rs_to_status = 'REQ_CHECKED_IN' THEN
+            END) AS reqs,
+        sum(
+            CASE WHEN rs_to_status = 'REQ_CANCELLED' THEN
                 1
             ELSE
                 0
-            END) / cast(sum(
-                CASE WHEN rs_to_status = 'REQ_VALIDATED' THEN
+            END) AS cancelled,
+        sum(
+            CASE WHEN rs_to_status = 'REQ_END_OF_ROTA' THEN
+                1
+            ELSE
+                0
+            END) AS unfilled,
+        sum(
+            CASE WHEN rs_to_status = 'REQ_CHECKED_IN'
+                OR rs_to_status = 'REQ_FILLED_LOCALLY' THEN
+                1
+            ELSE
+                0
+            END) AS received,
+        round((sum(
+                CASE WHEN rs_to_status = 'REQ_CHECKED_IN' THEN
                     1
                 ELSE
                     0
-                END) AS decimal)), 2) AS filled_ratio
-FROM
-    reshare_derived.req_stats;
+                END) / cast(sum(
+                    CASE WHEN rs_to_status = 'REQ_VALIDATED' THEN
+                        1
+                    ELSE
+                        0
+                    END) AS decimal)), 2) AS filled_ratio
+    FROM
+        reshare_derived.req_stats
+    GROUP BY
+        requester
+    UNION
+    SELECT
+        'consortium' AS requester,
+        sum(
+            CASE WHEN rs_to_status = 'REQ_VALIDATED' THEN
+                1
+            ELSE
+                0
+            END) AS reqs,
+        sum(
+            CASE WHEN rs_to_status = 'REQ_CANCELLED' THEN
+                1
+            ELSE
+                0
+            END) AS cancelled,
+        sum(
+            CASE WHEN rs_to_status = 'REQ_END_OF_ROTA' THEN
+                1
+            ELSE
+                0
+            END) AS unfilled,
+        sum(
+            CASE WHEN rs_to_status = 'REQ_CHECKED_IN'
+                OR rs_to_status = 'REQ_FILLED_LOCALLY' THEN
+                1
+            ELSE
+                0
+            END) AS received,
+        round((sum(
+                CASE WHEN rs_to_status = 'REQ_CHECKED_IN' THEN
+                    1
+                ELSE
+                    0
+                END) / cast(sum(
+                    CASE WHEN rs_to_status = 'REQ_VALIDATED' THEN
+                        1
+                    ELSE
+                        0
+                    END) AS decimal)), 2) AS filled_ratio
+    FROM
+        reshare_derived.req_stats
+    GROUP BY
+        requester) AS core_req
+ORDER BY
+    (
+        CASE WHEN core_req.requester = 'consortium' THEN
+            0
+        ELSE
+            1
+        END),
+    core_req.requester;
 

--- a/sql/report_queries/core_supplying/core_sup.sql
+++ b/sql/report_queries/core_supplying/core_sup.sql
@@ -1,90 +1,103 @@
 SELECT
-    ss_supplier AS supplier,
-    count(DISTINCT ss_req_id) AS reqs,
-    sum(
-        CASE WHEN ss_to_status = 'RES_UNFILLED' THEN
-            1
-        ELSE
+    *
+FROM (
+    SELECT
+        ss_supplier AS supplier,
+        count(DISTINCT ss_req_id) AS reqs,
+        sum(
+            CASE WHEN ss_to_status = 'RES_UNFILLED' THEN
+                1
+            ELSE
+                0
+            END) AS unfilled,
+        sum(
+            CASE WHEN ss_to_status = 'RES_AWAIT_SHIP' THEN
+                1
+            ELSE
+                0
+            END) AS filled,
+        sum(
+            CASE WHEN ss_to_status = 'RES_ITEM_SHIPPED'
+                AND ss_from_status = 'RES_AWAIT_SHIP' THEN
+                1
+            ELSE
+                0
+            END) AS shipped,
+        sum(
+            CASE WHEN ss_to_status = 'RES_CANCELLED' THEN
+                1
+            ELSE
+                0
+            END) AS cancels,
+        round(cast(sum(
+                    CASE WHEN ss_to_status = 'RES_AWAIT_SHIP' THEN
+                        1
+                    ELSE
+                        0
+                    END) AS decimal) / count(DISTINCT ss_req_id), 2) AS filled_ratio,
+        round(cast(sum(
+                    CASE WHEN ss_to_status = 'RES_ITEM_SHIPPED'
+                        AND ss_from_status = 'RES_AWAIT_SHIP' THEN
+                        1
+                    ELSE
+                        0
+                    END) AS decimal) / count(DISTINCT ss_req_id), 2) AS supplied_ratio
+    FROM
+        reshare_derived.sup_stats
+    GROUP BY
+        supplier
+    UNION
+    SELECT
+        'consortium' AS supplier,
+        count(DISTINCT ss_req_id) AS reqs,
+        sum(
+            CASE WHEN ss_to_status = 'RES_UNFILLED' THEN
+                1
+            ELSE
+                0
+            END) AS unfilled,
+        sum(
+            CASE WHEN ss_to_status = 'RES_AWAIT_SHIP' THEN
+                1
+            ELSE
+                0
+            END) AS filled,
+        sum(
+            CASE WHEN ss_to_status = 'RES_ITEM_SHIPPED'
+                AND ss_from_status = 'RES_AWAIT_SHIP' THEN
+                1
+            ELSE
+                0
+            END) AS shipped,
+        sum(
+            CASE WHEN ss_to_status = 'RES_CANCELLED' THEN
+                1
+            ELSE
+                0
+            END) AS cancels,
+        round(cast(sum(
+                    CASE WHEN ss_to_status = 'RES_AWAIT_SHIP' THEN
+                        1
+                    ELSE
+                        0
+                    END) AS decimal) / count(DISTINCT ss_req_id), 2) AS filled_ratio,
+        round(cast(sum(
+                    CASE WHEN ss_to_status = 'RES_ITEM_SHIPPED'
+                        AND ss_from_status = 'RES_AWAIT_SHIP' THEN
+                        1
+                    ELSE
+                        0
+                    END) AS decimal) / count(DISTINCT ss_req_id), 2) AS supplied_ratio
+    FROM
+        reshare_derived.sup_stats
+    GROUP BY
+        supplier) AS core_sup
+ORDER BY
+    (
+        CASE WHEN core_sup.supplier = 'consortium' THEN
             0
-        END) AS unfilled,
-    sum(
-        CASE WHEN ss_to_status = 'RES_AWAIT_SHIP' THEN
-            1
         ELSE
-            0
-        END) AS filled,
-    sum(
-        CASE WHEN ss_to_status = 'RES_ITEM_SHIPPED'
-            AND ss_from_status = 'RES_AWAIT_SHIP' THEN
             1
-        ELSE
-            0
-        END) AS shipped,
-    sum(
-        CASE WHEN ss_to_status = 'RES_CANCELLED' THEN
-            1
-        ELSE
-            0
-        END) AS cancels,
-    round(cast(sum(
-                CASE WHEN ss_to_status = 'RES_AWAIT_SHIP' THEN
-                    1
-                ELSE
-                    0
-                END) AS decimal) / count(DISTINCT ss_req_id), 2) AS filled_ratio,
-    round(cast(sum(
-                CASE WHEN ss_to_status = 'RES_ITEM_SHIPPED'
-                    AND ss_from_status = 'RES_AWAIT_SHIP' THEN
-                    1
-                ELSE
-                    0
-                END) AS decimal) / count(DISTINCT ss_req_id), 2) AS supplied_ratio
-FROM
-    reshare_derived.sup_stats
-GROUP BY
-    supplier
-UNION
-SELECT
-    'constorium' AS supplier,
-    count(DISTINCT ss_req_id) AS reqs,
-    sum(
-        CASE WHEN ss_to_status = 'RES_UNFILLED' THEN
-            1
-        ELSE
-            0
-        END) AS unfilled,
-    sum(
-        CASE WHEN ss_to_status = 'RES_AWAIT_SHIP' THEN
-            1
-        ELSE
-            0
-        END) AS filled,
-    sum(
-        CASE WHEN ss_to_status = 'RES_ITEM_SHIPPED'
-            AND ss_from_status = 'RES_AWAIT_SHIP' THEN
-            1
-        ELSE
-            0
-        END) AS shipped,
-    sum(
-        CASE WHEN ss_to_status = 'RES_CANCELLED' THEN
-            1
-        ELSE
-            0
-        END) AS cancels,
-    round(cast(sum(
-                CASE WHEN ss_to_status = 'RES_AWAIT_SHIP' THEN
-                    1
-                ELSE
-                    0
-                END) AS decimal) / count(DISTINCT ss_req_id), 2) AS filled_ratio,
-    round(cast(sum(
-                CASE WHEN ss_to_status = 'RES_ITEM_SHIPPED'
-                    AND ss_from_status = 'RES_AWAIT_SHIP' THEN
-                    1
-                ELSE
-                    0
-                END) AS decimal) / count(DISTINCT ss_req_id), 2) AS supplied_ratio
-FROM
-    reshare_derived.sup_stats;
+        END),
+    core_sup.supplier;
 


### PR DESCRIPTION
Per 9/22 meeting, trying to keep 'consortium' pinned to the top of the core report results.