### PR TITLE
Updating consortial reports to use more readable institution names.

### DIFF
--- a/sql/derived_tables/consortial_view.sql
+++ b/sql/derived_tables/consortial_view.sql
@@ -1,31 +1,44 @@
 DROP TABLE IF EXISTS reshare_derived.consortial_view;
 
-CREATE TABLE reshare_derived.consortial_view AS
-SELECT
+CREATE TABLE reshare_derived.consortial_view AS SELECT DISTINCT
     prr."__origin" AS cv_requester,
+    names.de_name AS cv_nice_requester,
     prr.prr_date_created AS cv_date_created,
     prr.prr_last_updated AS cv_last_updated,
-    prr.prr_directory_id_fk AS cv_directory_id_fk,
+    de.de_name AS cv_supplier,
     prr.prr_patron_request_fk AS cv_patron_request_fk,
     prr.prr_state_fk AS cv_state_fk,
     s.st_code AS cv_code
 FROM
     reshare_rs.patron_request_rota prr
     JOIN reshare_rs.status s ON s.st_id = prr.prr_state_fk
+    JOIN reshare_rs.symbol s2 ON prr.prr_peer_symbol_fk = s2.sym_id
+    JOIN reshare_rs.directory_entry de ON s2.sym_owner_fk = de.de_id
+    JOIN (
+        SELECT
+            *
+        FROM
+            reshare_rs.directory_entry de2
+        WHERE
+            de2.de_parent IS NULL
+            AND de2.de_status_fk IS NOT NULL) AS names ON prr."__origin" = names."__origin"
 WHERE
     s.st_code = 'REQ_REQUEST_COMPLETE'
     OR s.st_code = 'REQ_SHIPPED';
 
 CREATE INDEX ON reshare_derived.consortial_view (cv_requester);
 
+CREATE INDEX ON reshare_derived.consortial_view (cv_nice_requester);
+
 CREATE INDEX ON reshare_derived.consortial_view (cv_date_created);
 
 CREATE INDEX ON reshare_derived.consortial_view (cv_last_updated);
 
-CREATE INDEX ON reshare_derived.consortial_view (cv_directory_id_fk);
+CREATE INDEX ON reshare_derived.consortial_view (cv_supplier);
 
 CREATE INDEX ON reshare_derived.consortial_view (cv_patron_request_fk);
 
 CREATE INDEX ON reshare_derived.consortial_view (cv_state_fk);
 
 CREATE INDEX ON reshare_derived.consortial_view (cv_code);
+

--- a/sql/report_queries/consortial_requesting/consortial_requester.sql
+++ b/sql/report_queries/consortial_requesting/consortial_requester.sql
@@ -4,8 +4,8 @@ WITH parameters AS (
         '2030-01-01'::date AS end_date
 )
 SELECT
-    cv_requester AS requester,
-    cv_directory_id_fk AS supplier,
+    cv_nice_requester AS requester,
+    cv_supplier AS supplier,
     count(*) AS count_of_requests
 FROM
     reshare_derived.consortial_view cv
@@ -21,8 +21,8 @@ WHERE
         FROM
             parameters)
 GROUP BY
-    cv.cv_requester,
-    cv.cv_directory_id_fk
+    cv.cv_nice_requester,
+    cv.cv_supplier
 ORDER BY
-    cv.cv_requester;
+    cv.cv_nice_requester;
 

--- a/sql/report_queries/consortial_requesting/consortial_total_by_requester.sql
+++ b/sql/report_queries/consortial_requesting/consortial_total_by_requester.sql
@@ -4,7 +4,7 @@ WITH parameters AS (
         '2030-01-01'::date AS end_date
 )
 SELECT
-    cv_requester AS requester,
+    cv_nice_requester AS requester,
     count(*) AS count_of_requests
 FROM
     reshare_derived.consortial_view cv
@@ -20,7 +20,7 @@ WHERE
         FROM
             parameters)
 GROUP BY
-    cv.cv_requester
+    cv.cv_nice_requester
 ORDER BY
-    cv.cv_requester;
+    cv.cv_nice_requester;
 

--- a/sql/report_queries/consortial_supplying/consortial_supplier.sql
+++ b/sql/report_queries/consortial_supplying/consortial_supplier.sql
@@ -4,8 +4,8 @@ WITH parameters AS (
         '2030-01-01'::date AS end_date
 )
 SELECT
-    cv_directory_id_fk AS supplier,
-    cv_requester AS requester,
+    cv_supplier AS supplier,
+    cv_nice_requester AS requester,
     count(*) AS count_of_requests
 FROM
     reshare_derived.consortial_view cv
@@ -21,8 +21,8 @@ WHERE
         FROM
             parameters)
 GROUP BY
-    cv.cv_directory_id_fk,
-    cv_requester
+    cv.cv_supplier,
+    cv_nice_requester
 ORDER BY
-    cv.cv_directory_id_fk;
+    cv.cv_supplier;
 

--- a/sql/report_queries/consortial_supplying/consortial_total_by_supplier.sql
+++ b/sql/report_queries/consortial_supplying/consortial_total_by_supplier.sql
@@ -4,7 +4,7 @@ WITH parameters AS (
         '2030-01-01'::date AS end_date
 )
 SELECT
-    cv_directory_id_fk AS supplier,
+    cv_supplier AS supplier,
     count(*) AS count_of_requests
 FROM
     reshare_derived.consortial_view cv
@@ -20,7 +20,7 @@ WHERE
         FROM
             parameters)
 GROUP BY
-    cv.cv_directory_id_fk
+    cv.cv_supplier
 ORDER BY
-    cv.cv_directory_id_fk;
+    cv.cv_supplier;
 


### PR DESCRIPTION
Per discussion in the 1/19/22 ReShare Reporting check-in meeting, adding more readable institution names in the consortial reports. 