### PR TITLE
Add libraries that have no results to core reports.

### DIFF
--- a/sql/report_queries/core_requesting/core_req.sql
+++ b/sql/report_queries/core_requesting/core_req.sql
@@ -117,7 +117,36 @@ FROM (
                         FROM
                             parameters)
                     GROUP BY
-                        requester) AS core_req
+                        requester
+                    UNION
+                    SELECT
+                        de_name,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0
+                    FROM
+                        reshare_rs.directory_entry de
+                    WHERE
+                        de.de_parent IS NULL
+                        AND de.de_status_fk IS NOT NULL
+                        AND de.de_name NOT IN (
+                            SELECT
+                                rs.rs_requester_nice_name
+                            FROM
+                                reshare_derived.req_stats rs
+                            WHERE
+                                rs_date_created >= (
+                                    SELECT
+                                        start_date
+                                    FROM
+                                        parameters)
+                                    AND rs_date_created < (
+                                        SELECT
+                                            end_date
+                                        FROM
+                                            parameters))) AS core_req
 ORDER BY
     (
         CASE WHEN core_req.requester = 'Consortium' THEN

--- a/sql/report_queries/core_supplying/core_sup.sql
+++ b/sql/report_queries/core_supplying/core_sup.sql
@@ -118,7 +118,38 @@ FROM (
                         FROM
                             parameters)
                     GROUP BY
-                        supplier) AS core_sup
+                        supplier
+                    UNION
+                    SELECT
+                        de_name,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0
+                    FROM
+                        reshare_rs.directory_entry de
+                    WHERE
+                        de.de_parent IS NULL
+                        AND de.de_status_fk IS NOT NULL
+                        AND de.de_name NOT IN (
+                            SELECT
+                                ss.ss_supplier_nice_name
+                            FROM
+                                reshare_derived.sup_stats ss
+                            WHERE
+                                ss_date_created >= (
+                                    SELECT
+                                        start_date
+                                    FROM
+                                        parameters)
+                                    AND ss_date_created < (
+                                        SELECT
+                                            end_date
+                                        FROM
+                                            parameters))) AS core_sup
 ORDER BY
     (
         CASE WHEN core_sup.supplier = 'Consortium' THEN


### PR DESCRIPTION
Should satisfy the request in #38 to include an institution even when they have no statistics (request or supply) in the given time period.