### PR TITLE
Use current version of audit tables and bring over start values

### DIFF
--- a/sql/derived_tables/consortial_view.sql
+++ b/sql/derived_tables/consortial_view.sql
@@ -2,6 +2,7 @@ DROP TABLE IF EXISTS consortial_view;
 
 CREATE TABLE consortial_view AS SELECT DISTINCT
     prr.__origin AS cv_requester,
+    prr.__start AS cv_start,
     names.de_name AS cv_requester_nice_name,
     prr.prr_date_created AS cv_date_created,
     prr.prr_last_updated AS cv_last_updated,
@@ -25,12 +26,15 @@ FROM
             reshare_rs.directory_entry de2
         WHERE
             de2.de_parent IS NULL
-            AND de2.de_status_fk IS NOT NULL) AS names ON prr.__origin = names.__origin
+            AND de2.de_status_fk IS NOT NULL
+            AND de2.de_name NOT IN ('Bobst Circulation Desk', 'South Charleston Campus Collection')) AS names ON prr.__origin = names.__origin
 WHERE
     s.st_code = 'REQ_REQUEST_COMPLETE'
     OR s.st_code = 'REQ_SHIPPED';
 
 CREATE INDEX ON consortial_view (cv_requester);
+
+CREATE INDEX ON consortial_view (cv_start);
 
 CREATE INDEX ON consortial_view (cv_requester_nice_name);
 

--- a/sql/derived_tables/consortial_view.sql
+++ b/sql/derived_tables/consortial_view.sql
@@ -26,8 +26,7 @@ FROM
             reshare_rs.directory_entry de2
         WHERE
             de2.de_parent IS NULL
-            AND de2.de_status_fk IS NOT NULL
-            AND de2.de_name NOT IN ('Bobst Circulation Desk', 'South Charleston Campus Collection')) AS names ON prr.__origin = names.__origin
+            AND de2.de_status_fk IS NOT NULL) AS names ON prr.__origin = names.__origin
 WHERE
     s.st_code = 'REQ_REQUEST_COMPLETE'
     OR s.st_code = 'REQ_SHIPPED';

--- a/sql/derived_tables/consortial_view.sql
+++ b/sql/derived_tables/consortial_view.sql
@@ -12,8 +12,11 @@ CREATE TABLE consortial_view AS SELECT DISTINCT
 FROM
     reshare_rs.patron_request_rota prr
     JOIN reshare_rs.status s ON s.st_id = prr.prr_state_fk
+        AND prr.__origin = s.__origin
     JOIN reshare_rs.symbol s2 ON prr.prr_peer_symbol_fk::uuid = s2.sym_id
+        AND prr.__origin = s2.__origin
     JOIN reshare_rs.directory_entry de ON s2.sym_owner_fk = de.de_id
+        AND s2.__origin = de.__origin
     JOIN (
         SELECT
             de2.__origin,

--- a/sql/derived_tables/req_overdues.sql
+++ b/sql/derived_tables/req_overdues.sql
@@ -20,9 +20,13 @@ CREATE TABLE req_overdue AS SELECT DISTINCT
 FROM
     reshare_rs.patron_request pr
     JOIN reshare_rs.symbol s ON pr.pr_resolved_sup_inst_symbol_fk::uuid = s.sym_id
+        AND pr.__origin = s.__origin
     JOIN reshare_rs.status s2 ON pr.pr_state_fk = s2.st_id
+        AND pr.__origin = s2.__origin
     JOIN reshare_rs.symbol s3 ON pr.pr_resolved_req_inst_symbol_fk::uuid = s3.sym_id
+        AND pr.__origin = s3.__origin
     JOIN reshare_rs.directory_entry de ON s3.sym_owner_fk = de.de_id
+        AND s3.__origin = de.__origin
 WHERE
     pr.pr_due_date_rs::date < CURRENT_DATE
     AND s2.st_code LIKE 'REQ_%'

--- a/sql/derived_tables/req_overdues.sql
+++ b/sql/derived_tables/req_overdues.sql
@@ -2,6 +2,7 @@ DROP TABLE IF EXISTS req_overdue;
 
 CREATE TABLE req_overdue AS SELECT DISTINCT
     pr.__origin AS ro_requester,
+    pr.__start AS ro_start,
     de.de_name AS ro_requester_nice_name,
     pr.pr_hrid AS ro_hrid,
     pr.pr_title AS ro_title,
@@ -33,6 +34,8 @@ WHERE
     AND s2.st_code NOT LIKE '%_COMPLETE';
 
 CREATE INDEX ON req_overdue (ro_requester);
+
+CREATE INDEX ON req_overdue (ro_start);
 
 CREATE INDEX ON req_overdue (ro_requester_nice_name);
 

--- a/sql/derived_tables/req_stats.sql
+++ b/sql/derived_tables/req_stats.sql
@@ -17,7 +17,7 @@ FROM
     LEFT JOIN reshare_rs.status s ON pra.pra_to_status_fk = s.st_id
         AND pra.__origin = s.__origin
     LEFT JOIN reshare_rs.status s2 ON pra.pra_from_status_fk::uuid = s2.st_id
-        AND pra.__origin = s.__origin
+        AND pra.__origin = s2.__origin
     JOIN (
         SELECT
             de.__origin,

--- a/sql/derived_tables/req_stats.sql
+++ b/sql/derived_tables/req_stats.sql
@@ -4,6 +4,7 @@ DROP TABLE IF EXISTS req_stats;
 CREATE TABLE req_stats AS
 SELECT
     pra.__origin AS rs_requester,
+    pra.__start AS rs_start,
     names.de_name AS rs_requester_nice_name,
     pra.pra_id AS rs_id,
     pra.pra_patron_request_fk AS rs_req_id,
@@ -25,12 +26,15 @@ FROM
             reshare_rs.directory_entry de
         WHERE
             de.de_parent IS NULL
-            AND de.de_status_fk IS NOT NULL) AS names ON pra.__origin = names.__origin
+            AND de.de_status_fk IS NOT NULL
+            AND de.de_name NOT IN ('Bobst Circulation Desk', 'South Charleston Campus Collection')) AS names ON pra.__origin = names.__origin
 WHERE
     s.st_code LIKE 'REQ_%'
     OR s2.st_code LIKE 'REQ_%';
 
 CREATE INDEX ON req_stats (rs_requester);
+
+CREATE INDEX ON req_stats (rs_start);
 
 CREATE INDEX ON req_stats (rs_requester_nice_name);
 

--- a/sql/derived_tables/req_stats.sql
+++ b/sql/derived_tables/req_stats.sql
@@ -14,7 +14,9 @@ SELECT
 FROM
     reshare_rs.patron_request_audit pra
     LEFT JOIN reshare_rs.status s ON pra.pra_to_status_fk = s.st_id
+        AND pra.__origin = s.__origin
     LEFT JOIN reshare_rs.status s2 ON pra.pra_from_status_fk::uuid = s2.st_id
+        AND pra.__origin = s.__origin
     JOIN (
         SELECT
             de.__origin,

--- a/sql/derived_tables/req_stats.sql
+++ b/sql/derived_tables/req_stats.sql
@@ -26,8 +26,7 @@ FROM
             reshare_rs.directory_entry de
         WHERE
             de.de_parent IS NULL
-            AND de.de_status_fk IS NOT NULL
-            AND de.de_name NOT IN ('Bobst Circulation Desk', 'South Charleston Campus Collection')) AS names ON pra.__origin = names.__origin
+            AND de.de_status_fk IS NOT NULL) AS names ON pra.__origin = names.__origin
 WHERE
     s.st_code LIKE 'REQ_%'
     OR s2.st_code LIKE 'REQ_%';

--- a/sql/derived_tables/req_turnaround_detail_1.sql
+++ b/sql/derived_tables/req_turnaround_detail_1.sql
@@ -14,11 +14,17 @@ CREATE TABLE rtat_reqs AS SELECT DISTINCT
 FROM
     reshare_rs.patron_request pr
     LEFT JOIN reshare_rs.patron_request_audit__ pra ON pr.pr_id = pra.pra_patron_request_fk
+        AND pr.__origin = pra.__origin
     LEFT JOIN reshare_rs.status s ON pra.pra_to_status_fk = s.st_id
-    LEFT JOIN reshare_rs.symbol s2 ON pr.pr_resolved_req_inst_symbol_fk::uuid = s2.sym_id AND pr.__origin = s2.__origin
-    LEFT JOIN reshare_rs.symbol s3 ON pr.pr_resolved_sup_inst_symbol_fk::uuid = s3.sym_id AND pr.__origin = s3.__origin
-    LEFT JOIN reshare_rs.directory_entry de ON s2.sym_owner_fk = de.de_id AND s2.__origin = de.__origin
-    LEFT JOIN reshare_rs.directory_entry de2 ON s3.sym_owner_fk = de2.de_id AND s3.__origin = de2.__origin
+        AND pra.__origin = s.__origin
+    LEFT JOIN reshare_rs.symbol s2 ON pr.pr_resolved_req_inst_symbol_fk::uuid = s2.sym_id
+        AND pr.__origin = s2.__origin
+    LEFT JOIN reshare_rs.symbol s3 ON pr.pr_resolved_sup_inst_symbol_fk::uuid = s3.sym_id
+        AND pr.__origin = s3.__origin
+    LEFT JOIN reshare_rs.directory_entry de ON s2.sym_owner_fk = de.de_id
+        AND s2.__origin = de.__origin
+    LEFT JOIN reshare_rs.directory_entry de2 ON s3.sym_owner_fk = de2.de_id
+        AND s3.__origin = de2.__origin
 WHERE
     pr.pr_is_requester IS TRUE
     AND pr.pr_hrid IS NOT NULL;

--- a/sql/derived_tables/req_turnaround_detail_1.sql
+++ b/sql/derived_tables/req_turnaround_detail_1.sql
@@ -2,6 +2,7 @@ DROP TABLE IF EXISTS rtat_reqs;
 
 CREATE TABLE rtat_reqs AS SELECT DISTINCT
     pr.__origin AS rtr_requester,
+    pr.__start AS rtr_start,
     de.de_name AS rtr_requester_nice_name,
     pr.pr_hrid AS rtr_hrid,
     pr.pr_title AS rtr_title,
@@ -13,23 +14,21 @@ CREATE TABLE rtat_reqs AS SELECT DISTINCT
     pr.pr_id AS rtr_id
 FROM
     reshare_rs.patron_request pr
-    LEFT JOIN reshare_rs.patron_request_audit__ pra ON pr.pr_id = pra.pra_patron_request_fk
-        AND pr.__origin = pra.__origin
-    LEFT JOIN reshare_rs.status s ON pra.pra_to_status_fk = s.st_id
-        AND pra.__origin = s.__origin
-    LEFT JOIN reshare_rs.symbol s2 ON pr.pr_resolved_req_inst_symbol_fk::uuid = s2.sym_id
+    LEFT JOIN reshare_rs.symbol s ON pr.pr_resolved_req_inst_symbol_fk::uuid = s.sym_id
+        AND pr.__origin = s.__origin
+    LEFT JOIN reshare_rs.symbol s2 ON pr.pr_resolved_sup_inst_symbol_fk::uuid = s2.sym_id
         AND pr.__origin = s2.__origin
-    LEFT JOIN reshare_rs.symbol s3 ON pr.pr_resolved_sup_inst_symbol_fk::uuid = s3.sym_id
-        AND pr.__origin = s3.__origin
-    LEFT JOIN reshare_rs.directory_entry de ON s2.sym_owner_fk = de.de_id
-        AND s2.__origin = de.__origin
-    LEFT JOIN reshare_rs.directory_entry de2 ON s3.sym_owner_fk = de2.de_id
-        AND s3.__origin = de2.__origin
+    LEFT JOIN reshare_rs.directory_entry de ON s.sym_owner_fk = de.de_id
+        AND s.__origin = de.__origin
+    LEFT JOIN reshare_rs.directory_entry de2 ON s2.sym_owner_fk = de2.de_id
+        AND s2.__origin = de2.__origin
 WHERE
     pr.pr_is_requester IS TRUE
     AND pr.pr_hrid IS NOT NULL;
 
 CREATE INDEX ON rtat_reqs (rtr_requester);
+
+CREATE INDEX ON rtat_reqs (rtr_start);
 
 CREATE INDEX ON rtat_reqs (rtr_requester_nice_name);
 

--- a/sql/derived_tables/req_turnaround_detail_2.sql
+++ b/sql/derived_tables/req_turnaround_detail_2.sql
@@ -9,7 +9,9 @@ CREATE TABLE rtat_ship AS SELECT DISTINCT
 FROM
     reshare_rs.patron_request_audit__ pra
     LEFT JOIN reshare_rs.status s ON pra.pra_from_status_fk::uuid = s.st_id
+        AND pra.__origin = s.__origin
     LEFT JOIN reshare_rs.status s2 ON pra.pra_to_status_fk = s2.st_id
+        AND pra.__origin = s2.__origin
 WHERE (s.st_code = 'REQ_EXPECTS_TO_SUPPLY'
     OR s.st_code = 'REQ_CONDITIONAL_ANSWER_RECEIVED')
 AND s2.st_code = 'REQ_SHIPPED';
@@ -25,3 +27,4 @@ CREATE INDEX ON rtat_ship (rts_from_status);
 CREATE INDEX ON rtat_ship (rts_to_status);
 
 VACUUM ANALYZE rtat_ship;
+

--- a/sql/derived_tables/req_turnaround_detail_2.sql
+++ b/sql/derived_tables/req_turnaround_detail_2.sql
@@ -2,12 +2,13 @@ DROP TABLE IF EXISTS rtat_ship;
 
 CREATE TABLE rtat_ship AS SELECT DISTINCT
     pra.__origin AS rts_requester,
+    pra.__start AS rts_start,
     pra.pra_date_created AS rts_date_created,
     pra.pra_patron_request_fk AS rts_req_id,
     s.st_code AS rts_from_status,
     s2.st_code AS rts_to_status
 FROM
-    reshare_rs.patron_request_audit__ pra
+    reshare_rs.patron_request_audit pra
     LEFT JOIN reshare_rs.status s ON pra.pra_from_status_fk::uuid = s.st_id
         AND pra.__origin = s.__origin
     LEFT JOIN reshare_rs.status s2 ON pra.pra_to_status_fk = s2.st_id
@@ -17,6 +18,8 @@ WHERE (s.st_code = 'REQ_EXPECTS_TO_SUPPLY'
 AND s2.st_code = 'REQ_SHIPPED';
 
 CREATE INDEX ON rtat_ship (rts_requester);
+
+CREATE INDEX ON rtat_ship (rts_start);
 
 CREATE INDEX ON rtat_ship (rts_date_created);
 

--- a/sql/derived_tables/req_turnaround_detail_3.sql
+++ b/sql/derived_tables/req_turnaround_detail_3.sql
@@ -8,6 +8,7 @@ CREATE TABLE rtat_rec AS SELECT DISTINCT
 FROM
     reshare_rs.patron_request_audit__ pra
     LEFT JOIN reshare_rs.status s ON pra.pra_to_status_fk = s.st_id
+        AND pra.__origin = s.__origin
 WHERE
     s.st_code = 'REQ_CHECKED_IN';
 
@@ -20,3 +21,4 @@ CREATE INDEX ON rtat_rec (rtre_req_id);
 CREATE INDEX ON rtat_rec (rtre_status);
 
 VACUUM ANALYZE rtat_rec;
+

--- a/sql/derived_tables/req_turnaround_detail_3.sql
+++ b/sql/derived_tables/req_turnaround_detail_3.sql
@@ -2,17 +2,20 @@ DROP TABLE IF EXISTS rtat_rec;
 
 CREATE TABLE rtat_rec AS SELECT DISTINCT
     pra.__origin AS rtre_requester,
+    pra.__start AS rtre_start,
     pra.pra_date_created AS rtre_date_created,
     pra.pra_patron_request_fk AS rtre_req_id,
     s.st_code AS rtre_status
 FROM
-    reshare_rs.patron_request_audit__ pra
+    reshare_rs.patron_request_audit pra
     LEFT JOIN reshare_rs.status s ON pra.pra_to_status_fk = s.st_id
         AND pra.__origin = s.__origin
 WHERE
     s.st_code = 'REQ_CHECKED_IN';
 
 CREATE INDEX ON rtat_rec (rtre_requester);
+
+CREATE INDEX ON rtat_rec (rtre_start);
 
 CREATE INDEX ON rtat_rec (rtre_date_created);
 

--- a/sql/derived_tables/sup_overdues.sql
+++ b/sql/derived_tables/sup_overdues.sql
@@ -2,6 +2,7 @@ DROP TABLE IF EXISTS sup_overdue;
 
 CREATE TABLE sup_overdue AS SELECT DISTINCT
     pr.__origin AS so_supplier,
+    pr.__start AS so_start,
     de.de_name AS so_supplier_nice_name,
     pr.pr_hrid AS so_hrid,
     pr.pr_title AS so_title,
@@ -27,6 +28,8 @@ WHERE
     AND s2.st_code NOT LIKE '%_COMPLETE';
 
 CREATE INDEX ON sup_overdue (so_supplier);
+
+CREATE INDEX ON sup_overdue (so_start);
 
 CREATE INDEX ON sup_overdue (so_supplier_nice_name);
 

--- a/sql/derived_tables/sup_overdues.sql
+++ b/sql/derived_tables/sup_overdues.sql
@@ -16,8 +16,11 @@ CREATE TABLE sup_overdue AS SELECT DISTINCT
 FROM
     reshare_rs.patron_request pr
     JOIN reshare_rs.symbol s ON pr.pr_resolved_sup_inst_symbol_fk::uuid = s.sym_id
+        AND pr.__origin = s.__origin
     JOIN reshare_rs.status s2 ON pr.pr_state_fk = s2.st_id
+        AND pr.__origin = s2.__origin
     JOIN reshare_rs.directory_entry de ON s.sym_owner_fk = de.de_id
+        AND s.__origin = de.__origin
 WHERE
     pr.pr_due_date_rs::date < CURRENT_DATE
     AND s2.st_code LIKE 'RES_%'
@@ -48,3 +51,4 @@ CREATE INDEX ON sup_overdue (so_item_barcode);
 CREATE INDEX ON sup_overdue (so_last_updated);
 
 VACUUM ANALYZE sup_overdue;
+

--- a/sql/derived_tables/sup_stats.sql
+++ b/sql/derived_tables/sup_stats.sql
@@ -14,7 +14,9 @@ SELECT
 FROM
     reshare_rs.patron_request_audit pra
     LEFT JOIN reshare_rs.status s ON pra.pra_to_status_fk = s.st_id
+        AND pra.__origin = s.__origin
     LEFT JOIN reshare_rs.status s2 ON pra.pra_from_status_fk::uuid = s2.st_id
+        AND pra.__origin = s2.__origin
     JOIN (
         SELECT
             de.__origin,

--- a/sql/derived_tables/sup_stats.sql
+++ b/sql/derived_tables/sup_stats.sql
@@ -4,6 +4,7 @@ DROP TABLE IF EXISTS sup_stats;
 CREATE TABLE sup_stats AS
 SELECT
     pra.__origin AS ss_supplier,
+    pra.__start AS ss_start,
     names.de_name AS ss_supplier_nice_name,
     pra.pra_id AS ss_id,
     pra.pra_patron_request_fk AS ss_req_id,
@@ -25,13 +26,16 @@ FROM
             reshare_rs.directory_entry de
         WHERE
             de.de_parent IS NULL
-            AND de.de_status_fk IS NOT NULL) AS names ON pra.__origin = names.__origin
+            AND de.de_status_fk IS NOT NULL
+            AND de.de_name NOT IN ('Bobst Circulation Desk', 'South Charleston Campus Collection')) AS names ON pra.__origin = names.__origin
 WHERE
     s.st_code LIKE 'RES_%'
     AND (s2.st_code LIKE 'RES_%'
         OR s2.st_code IS NULL);
 
 CREATE INDEX ON sup_stats (ss_supplier);
+
+CREATE INDEX ON sup_stats (ss_start);
 
 CREATE INDEX ON sup_stats (ss_supplier_nice_name);
 

--- a/sql/derived_tables/sup_stats.sql
+++ b/sql/derived_tables/sup_stats.sql
@@ -26,8 +26,7 @@ FROM
             reshare_rs.directory_entry de
         WHERE
             de.de_parent IS NULL
-            AND de.de_status_fk IS NOT NULL
-            AND de.de_name NOT IN ('Bobst Circulation Desk', 'South Charleston Campus Collection')) AS names ON pra.__origin = names.__origin
+            AND de.de_status_fk IS NOT NULL) AS names ON pra.__origin = names.__origin
 WHERE
     s.st_code LIKE 'RES_%'
     AND (s2.st_code LIKE 'RES_%'

--- a/sql/derived_tables/sup_turnaround_detail_1.sql
+++ b/sql/derived_tables/sup_turnaround_detail_1.sql
@@ -14,9 +14,13 @@ CREATE TABLE stat_reqs AS SELECT DISTINCT
 FROM
     reshare_rs.patron_request pr
     LEFT JOIN reshare_rs.patron_request_audit__ pra ON pr.pr_id = pra.pra_patron_request_fk
+        AND pr.__origin = pra.__origin
     LEFT JOIN reshare_rs.status s ON pra.pra_to_status_fk = s.st_id
-    LEFT JOIN reshare_rs.symbol s2 ON pr.pr_resolved_req_inst_symbol_fk::uuid = s2.sym_id AND pr.__origin = s2.__origin
-    LEFT JOIN reshare_rs.directory_entry de ON s2.sym_owner_fk = de.de_id AND s2.__origin = de.__origin
+        AND pra.__origin = s.__origin
+    LEFT JOIN reshare_rs.symbol s2 ON pr.pr_resolved_req_inst_symbol_fk::uuid = s2.sym_id
+        AND pr.__origin = s2.__origin
+    LEFT JOIN reshare_rs.directory_entry de ON s2.sym_owner_fk = de.de_id
+        AND s2.__origin = de.__origin
     JOIN (
         SELECT
             de2.__origin,

--- a/sql/derived_tables/sup_turnaround_detail_1.sql
+++ b/sql/derived_tables/sup_turnaround_detail_1.sql
@@ -26,8 +26,7 @@ FROM
             reshare_rs.directory_entry de2
         WHERE
             de2.de_parent IS NULL
-            AND de2.de_status_fk IS NOT NULL
-            AND de2.de_name NOT IN ('Bobst Circulation Desk', 'South Charleston Campus Collection')) AS names ON pr.__origin = names.__origin
+            AND de2.de_status_fk IS NOT NULL) AS names ON pr.__origin = names.__origin
 WHERE
     pr.pr_is_requester IS FALSE
     AND pr.pr_hrid IS NOT NULL

--- a/sql/derived_tables/sup_turnaround_detail_1.sql
+++ b/sql/derived_tables/sup_turnaround_detail_1.sql
@@ -2,6 +2,7 @@ DROP TABLE IF EXISTS stat_reqs;
 
 CREATE TABLE stat_reqs AS SELECT DISTINCT
     pr.__origin AS str_supplier,
+    pr.__start AS str_start,
     names.de_name AS str_supplier_nice_name,
     pr.pr_hrid AS str_hrid,
     pr.pr_title AS str_title,
@@ -13,14 +14,10 @@ CREATE TABLE stat_reqs AS SELECT DISTINCT
     pr.pr_id AS str_id
 FROM
     reshare_rs.patron_request pr
-    LEFT JOIN reshare_rs.patron_request_audit__ pra ON pr.pr_id = pra.pra_patron_request_fk
-        AND pr.__origin = pra.__origin
-    LEFT JOIN reshare_rs.status s ON pra.pra_to_status_fk = s.st_id
-        AND pra.__origin = s.__origin
-    LEFT JOIN reshare_rs.symbol s2 ON pr.pr_resolved_req_inst_symbol_fk::uuid = s2.sym_id
-        AND pr.__origin = s2.__origin
-    LEFT JOIN reshare_rs.directory_entry de ON s2.sym_owner_fk = de.de_id
-        AND s2.__origin = de.__origin
+    LEFT JOIN reshare_rs.symbol s ON pr.pr_resolved_req_inst_symbol_fk::uuid = s.sym_id
+        AND pr.__origin = s.__origin
+    LEFT JOIN reshare_rs.directory_entry de ON s.sym_owner_fk = de.de_id
+        AND s.__origin = de.__origin
     JOIN (
         SELECT
             de2.__origin,
@@ -29,13 +26,16 @@ FROM
             reshare_rs.directory_entry de2
         WHERE
             de2.de_parent IS NULL
-            AND de2.de_status_fk IS NOT NULL) AS names ON pr.__origin = names.__origin
+            AND de2.de_status_fk IS NOT NULL
+            AND de2.de_name NOT IN ('Bobst Circulation Desk', 'South Charleston Campus Collection')) AS names ON pr.__origin = names.__origin
 WHERE
     pr.pr_is_requester IS FALSE
     AND pr.pr_hrid IS NOT NULL
     AND pr.pr_resolved_req_inst_symbol_fk != pr.pr_resolved_sup_inst_symbol_fk;
 
 CREATE INDEX ON stat_reqs (str_supplier);
+
+CREATE INDEX ON stat_reqs (str_start);
 
 CREATE INDEX ON stat_reqs (str_supplier_nice_name);
 

--- a/sql/derived_tables/sup_turnaround_detail_2.sql
+++ b/sql/derived_tables/sup_turnaround_detail_2.sql
@@ -2,12 +2,13 @@ DROP TABLE IF EXISTS stat_assi;
 
 CREATE TABLE stat_assi AS SELECT DISTINCT
     pra.__origin AS sta_supplier,
+    pra.__start AS sta_start,
     pra.pra_date_created AS sta_date_created,
     pra.pra_patron_request_fk AS sta_req_id,
     s.st_code AS sta_from_status,
     s2.st_code AS sta_to_status
 FROM
-    reshare_rs.patron_request_audit__ pra
+    reshare_rs.patron_request_audit pra
     LEFT JOIN reshare_rs.status s ON pra.pra_from_status_fk::uuid = s.st_id
         AND pra.__origin = s.__origin
     LEFT JOIN reshare_rs.status s2 ON pra.pra_to_status_fk = s2.st_id
@@ -17,6 +18,8 @@ WHERE
     AND s2.st_code = 'RES_IDLE';
 
 CREATE INDEX ON stat_assi (sta_supplier);
+
+CREATE INDEX ON stat_assi (sta_start);
 
 CREATE INDEX ON stat_assi (sta_date_created);
 

--- a/sql/derived_tables/sup_turnaround_detail_2.sql
+++ b/sql/derived_tables/sup_turnaround_detail_2.sql
@@ -9,7 +9,9 @@ CREATE TABLE stat_assi AS SELECT DISTINCT
 FROM
     reshare_rs.patron_request_audit__ pra
     LEFT JOIN reshare_rs.status s ON pra.pra_from_status_fk::uuid = s.st_id
+        AND pra.__origin = s.__origin
     LEFT JOIN reshare_rs.status s2 ON pra.pra_to_status_fk = s2.st_id
+        AND pra.__origin = s2.__origin
 WHERE
     s.st_code IS NULL
     AND s2.st_code = 'RES_IDLE';
@@ -25,3 +27,4 @@ CREATE INDEX ON stat_assi (sta_from_status);
 CREATE INDEX ON stat_assi (sta_to_status);
 
 VACUUM ANALYZE stat_assi;
+

--- a/sql/derived_tables/sup_turnaround_detail_3.sql
+++ b/sql/derived_tables/sup_turnaround_detail_3.sql
@@ -9,7 +9,9 @@ CREATE TABLE stat_fill AS SELECT DISTINCT
 FROM
     reshare_rs.patron_request_audit__ pra
     LEFT JOIN reshare_rs.status s ON pra.pra_from_status_fk::uuid = s.st_id
+        AND pra.__origin = s.__origin
     LEFT JOIN reshare_rs.status s2 ON pra.pra_to_status_fk = s2.st_id
+        AND pra.__origin = s2.__origin
 WHERE
     s.st_code = 'RES_AWAIT_PICKING'
     AND s2.st_code = 'RES_AWAIT_SHIP';
@@ -25,3 +27,4 @@ CREATE INDEX ON stat_fill (stf_from_status);
 CREATE INDEX ON stat_fill (stf_to_status);
 
 VACUUM ANALYZE stat_fill;
+

--- a/sql/derived_tables/sup_turnaround_detail_3.sql
+++ b/sql/derived_tables/sup_turnaround_detail_3.sql
@@ -2,12 +2,13 @@ DROP TABLE IF EXISTS stat_fill;
 
 CREATE TABLE stat_fill AS SELECT DISTINCT
     pra.__origin AS stf_supplier,
+    pra.__start AS stf_start,
     pra.pra_date_created AS stf_date_created,
     pra.pra_patron_request_fk AS stf_req_id,
     s.st_code AS stf_from_status,
     s2.st_code AS stf_to_status
 FROM
-    reshare_rs.patron_request_audit__ pra
+    reshare_rs.patron_request_audit pra
     LEFT JOIN reshare_rs.status s ON pra.pra_from_status_fk::uuid = s.st_id
         AND pra.__origin = s.__origin
     LEFT JOIN reshare_rs.status s2 ON pra.pra_to_status_fk = s2.st_id
@@ -17,6 +18,8 @@ WHERE
     AND s2.st_code = 'RES_AWAIT_SHIP';
 
 CREATE INDEX ON stat_fill (stf_supplier);
+
+CREATE INDEX ON stat_fill (stf_start);
 
 CREATE INDEX ON stat_fill (stf_date_created);
 

--- a/sql/derived_tables/sup_turnaround_detail_4.sql
+++ b/sql/derived_tables/sup_turnaround_detail_4.sql
@@ -9,7 +9,9 @@ CREATE TABLE stat_ship AS SELECT DISTINCT
 FROM
     reshare_rs.patron_request_audit__ pra
     LEFT JOIN reshare_rs.status s ON pra.pra_from_status_fk::uuid = s.st_id
+        AND pra.__origin = s.__origin
     LEFT JOIN reshare_rs.status s2 ON pra.pra_to_status_fk = s2.st_id
+        AND pra.__origin = s2.__origin
 WHERE
     s.st_code = 'RES_AWAIT_SHIP'
     AND s2.st_code = 'RES_ITEM_SHIPPED';
@@ -25,3 +27,4 @@ CREATE INDEX ON stat_ship (sts_from_status);
 CREATE INDEX ON stat_ship (sts_to_status);
 
 VACUUM ANALYZE stat_ship;
+

--- a/sql/derived_tables/sup_turnaround_detail_4.sql
+++ b/sql/derived_tables/sup_turnaround_detail_4.sql
@@ -2,12 +2,13 @@ DROP TABLE IF EXISTS stat_ship;
 
 CREATE TABLE stat_ship AS SELECT DISTINCT
     pra.__origin AS sts_supplier,
+    pra.__start AS sts_start,
     pra.pra_date_created AS sts_date_created,
     pra.pra_patron_request_fk AS sts_req_id,
     s.st_code AS sts_from_status,
     s2.st_code AS sts_to_status
 FROM
-    reshare_rs.patron_request_audit__ pra
+    reshare_rs.patron_request_audit pra
     LEFT JOIN reshare_rs.status s ON pra.pra_from_status_fk::uuid = s.st_id
         AND pra.__origin = s.__origin
     LEFT JOIN reshare_rs.status s2 ON pra.pra_to_status_fk = s2.st_id
@@ -17,6 +18,8 @@ WHERE
     AND s2.st_code = 'RES_ITEM_SHIPPED';
 
 CREATE INDEX ON stat_ship (sts_supplier);
+
+CREATE INDEX ON stat_ship (sts_start);
 
 CREATE INDEX ON stat_ship (sts_date_created);
 

--- a/sql/derived_tables/sup_turnaround_detail_5.sql
+++ b/sql/derived_tables/sup_turnaround_detail_5.sql
@@ -3,12 +3,13 @@ DROP TABLE IF EXISTS stat_rec;
 
 CREATE TABLE stat_rec AS SELECT DISTINCT
     pra.__origin AS stre_supplier,
+    pra.__start AS stre_start,
     (array_agg(pra.pra_date_created ORDER BY pra.pra_date_created ASC))[1] AS stre_date_created,
     pra.pra_patron_request_fk AS stre_req_id,
     s.st_code AS stre_from_status,
     s2.st_code AS stre_to_status
 FROM
-    reshare_rs.patron_request_audit__ pra
+    reshare_rs.patron_request_audit pra
     LEFT JOIN reshare_rs.status s ON pra.pra_from_status_fk::uuid = s.st_id
         AND pra.__origin = s.__origin
     LEFT JOIN reshare_rs.status s2 ON pra.pra_to_status_fk = s2.st_id
@@ -20,9 +21,12 @@ GROUP BY
     pra.pra_patron_request_fk,
     s.st_code,
     s2.st_code,
-    pra.__origin;
+    pra.__origin,
+    pra.__start;
 
 CREATE INDEX ON stat_rec (stre_supplier);
+
+CREATE INDEX ON stat_rec (stre_start);
 
 CREATE INDEX ON stat_rec (stre_date_created);
 

--- a/sql/derived_tables/sup_turnaround_detail_5.sql
+++ b/sql/derived_tables/sup_turnaround_detail_5.sql
@@ -10,7 +10,9 @@ CREATE TABLE stat_rec AS SELECT DISTINCT
 FROM
     reshare_rs.patron_request_audit__ pra
     LEFT JOIN reshare_rs.status s ON pra.pra_from_status_fk::uuid = s.st_id
+        AND pra.__origin = s.__origin
     LEFT JOIN reshare_rs.status s2 ON pra.pra_to_status_fk = s2.st_id
+        AND pra.__origin = s2.__origin
 WHERE
     s.st_code = 'RES_ITEM_SHIPPED'
     AND s2.st_code = 'RES_ITEM_SHIPPED'
@@ -31,3 +33,4 @@ CREATE INDEX ON stat_rec (stre_from_status);
 CREATE INDEX ON stat_rec (stre_to_status);
 
 VACUUM ANALYZE stat_rec;
+

--- a/sql/derived_tables/sup_turnaround_detail_6.sql
+++ b/sql/derived_tables/sup_turnaround_detail_6.sql
@@ -2,6 +2,7 @@ DROP TABLE IF EXISTS sup_tat_stats;
 
 CREATE TABLE sup_tat_stats AS SELECT DISTINCT
     ss_supplier_nice_name AS stst_supplier,
+    ss_start AS stst_start,
     (array_agg(ss_date_created ORDER BY ss_date_created ASC))[1] AS stst_date_created,
     ss_req_id AS stst_req_id,
     ss_from_status AS stst_from_status,
@@ -14,9 +15,12 @@ GROUP BY
     stst_from_status,
     stst_to_status,
     stst_message,
-    stst_supplier;
+    stst_supplier,
+    stst_start;
 
 CREATE INDEX ON sup_tat_stats (stst_supplier);
+
+CREATE INDEX ON sup_tat_stats (stst_start);
 
 CREATE INDEX ON sup_tat_stats (stst_date_created);
 
@@ -29,3 +33,4 @@ CREATE INDEX ON sup_tat_stats (stst_to_status);
 CREATE INDEX ON sup_tat_stats (stst_message);
 
 VACUUM ANALYZE sup_tat_stats;
+

--- a/sql/report_queries/consortial_requesting/README.md
+++ b/sql/report_queries/consortial_requesting/README.md
@@ -4,8 +4,7 @@
 
 Brief description: This report provides numbers of requests between institutions across the consortium.
 
-NOTE: As of January 2022, this report is INCOMPLETE.  Use the Core Requesting report instead.
-ALSO NOTE: The display format does not match the SME mockup, but the data are there.
+NOTE: The display format does not match the SME mockup, but will display as desired if using the [ReShare Reports Portal](https://github.com/indexdata/reshare-reports-portal).
 
 The consortial_requester.sql file will generate data in the following format:
 

--- a/sql/report_queries/consortial_supplying/README.md
+++ b/sql/report_queries/consortial_supplying/README.md
@@ -4,8 +4,7 @@
 
 Brief description: This report provides numbers of fills between institutions across the consortium.
 
-NOTE: As of January 2022, this report is INCOMPLETE.  Use the Core Requesting report instead.
-ALSO NOTE: The display format does not match the SME mockup, but the data are there.
+NOTE: The display format does not match the SME mockup, but will display as desired if using the [ReShare Reports Portal](https://github.com/indexdata/reshare-reports-portal).
 
 The consortial_supplier.sql file will generate data in the following format:
 

--- a/sql/report_queries/core_requesting/README.md
+++ b/sql/report_queries/core_requesting/README.md
@@ -2,18 +2,19 @@
 
 ## Report details
 
-**Brief description**: This report provides counts of total requests placed and total request outcomes: cancelled, unfilled, or received. Note that requests that are still in progress do not yet have an outcome and are not included in this report. For that reason, the total count of outcomes will not equal the total count of requests.
+**Brief description**: This report provides counts of total requests placed and total request outcomes: cancelled, unfilled, filled locally, or received. Note that requests that are still in progress do not yet have an outcome and are not included in this report. For that reason, the total count of outcomes will not equal the total count of requests.
 
 This report generates data in the following format:
 
-|requester|reqs|cancelled|unfilled|received|filled\_ratio|
-|------------|--------|----------|----------|----------|------------|
-|East University|253|6|63|176|0.69|
-|West University|3448|20|1018|2246|0.63|
+|requester|reqs|cancelled|unfilled|filled\_locally|received|filled\_ratio|
+|------------|--------|----------|----------|----------|------------|------------|
+|East University|253|6|63|3|176|0.69|
+|West University|3448|20|1018|27|2246|0.63|
 
 ## Data dictionary
 * **Requester**: The institution affiliated with the patron who placed the request.
 * **Reqs**: A count of valid requests placed by the institution's patrons. Note that this count does not currently include requests that were unable to be validated, including requests with invalid patron IDs.
 * **Cancelled**: A count of requests that have entered the "Cancelled" state. These requests were manually cancelled by the requesting library.
 * **Unfilled**: A count of requests that have entered the "End of rota" state. These requests were unable to be be supplied by any of the candidate suppliers.
-* **Received**: A count of requests that have entered the "In local circulation process" state. When evaluating requesting, the primary measure of success is that the item arrived at the requesting library and was received in the ReShare system. Successful return to the supplying library is captured in the Core Supplying Statistics report. Note that received requests may be in a variety of states at the time of reporting, including "Awaiting return shipping," "Complete," "Filled locally," "In local circulation process," "Overdue," or "Return shipped." 
+* **Filled Locally**: A count of requests that have entered the "Filled locally" state.  These are counted as filled requests (along with Received) for the purposes of the filled ratio.
+* **Received**: A count of requests that have entered the "In local circulation process" state. When evaluating requesting, the primary measure of success is that the item arrived at the requesting library and was received in the ReShare system. Successful return to the supplying library is captured in the Core Supplying Statistics report. Note that received requests may be in a variety of states at the time of reporting, including "Awaiting return shipping," "Complete," "In local circulation process," "Overdue," or "Return shipped." 

--- a/sql/report_queries/core_requesting/core_req.sql
+++ b/sql/report_queries/core_requesting/core_req.sql
@@ -10,7 +10,9 @@ FROM (
     SELECT
         rs_requester_nice_name AS requester,
         sum(
-            CASE WHEN rs_to_status = 'REQ_VALIDATED' THEN
+            CASE WHEN (rs_from_status = 'REQ_IDLE'
+                OR rs_from_status = 'REQ_INVALID_PATRON')
+                AND rs_to_status = 'REQ_VALIDATED' THEN
                 1
             ELSE
                 0
@@ -49,7 +51,9 @@ FROM (
                     ELSE
                         0
                     END) / nullif (cast(sum(
-                            CASE WHEN rs_to_status = 'REQ_VALIDATED' THEN
+                            CASE WHEN (rs_from_status = 'REQ_IDLE'
+                                OR rs_from_status = 'REQ_INVALID_PATRON')
+                                AND rs_to_status = 'REQ_VALIDATED' THEN
                                 1
                             ELSE
                                 0
@@ -73,7 +77,9 @@ FROM (
             SELECT
                 'Consortium' AS requester,
                 sum(
-                    CASE WHEN rs_to_status = 'REQ_VALIDATED' THEN
+                    CASE WHEN (rs_from_status = 'REQ_IDLE'
+                        OR rs_from_status = 'REQ_INVALID_PATRON')
+                        AND rs_to_status = 'REQ_VALIDATED' THEN
                         1
                     ELSE
                         0
@@ -112,7 +118,9 @@ FROM (
                             ELSE
                                 0
                             END) / nullif (cast(sum(
-                                    CASE WHEN rs_to_status = 'REQ_VALIDATED' THEN
+                                    CASE WHEN (rs_from_status = 'REQ_IDLE'
+                                        OR rs_from_status = 'REQ_INVALID_PATRON')
+                                        AND rs_to_status = 'REQ_VALIDATED' THEN
                                         1
                                     ELSE
                                         0

--- a/sql/report_queries/core_requesting/core_req.sql
+++ b/sql/report_queries/core_requesting/core_req.sql
@@ -28,9 +28,14 @@ FROM (
                 0
             END) AS unfilled,
         sum(
+            CASE WHEN rs_to_status = 'REQ_FILLED_LOCALLY' THEN
+                1
+            ELSE
+                0
+            END) AS filled_locally,
+        sum(
             CASE WHEN (rs_from_status = 'REQ_SHIPPED'
-                AND rs_to_status = 'REQ_CHECKED_IN')
-                OR rs_to_status = 'REQ_FILLED_LOCALLY' THEN
+                AND rs_to_status = 'REQ_CHECKED_IN') THEN
                 1
             ELSE
                 0
@@ -38,6 +43,8 @@ FROM (
         round(coalesce((sum(
                     CASE WHEN (rs_from_status = 'REQ_SHIPPED'
                         AND rs_to_status = 'REQ_CHECKED_IN') THEN
+                        1
+                    WHEN rs_to_status = 'REQ_FILLED_LOCALLY' THEN
                         1
                     ELSE
                         0
@@ -84,9 +91,14 @@ FROM (
                         0
                     END) AS unfilled,
                 sum(
+                    CASE WHEN rs_to_status = 'REQ_FILLED_LOCALLY' THEN
+                        1
+                    ELSE
+                        0
+                    END) AS filled_locally,
+                sum(
                     CASE WHEN (rs_from_status = 'REQ_SHIPPED'
-                        AND rs_to_status = 'REQ_CHECKED_IN')
-                        OR rs_to_status = 'REQ_FILLED_LOCALLY' THEN
+                        AND rs_to_status = 'REQ_CHECKED_IN') THEN
                         1
                     ELSE
                         0
@@ -94,6 +106,8 @@ FROM (
                 round(coalesce((sum(
                             CASE WHEN (rs_from_status = 'REQ_SHIPPED'
                                 AND rs_to_status = 'REQ_CHECKED_IN') THEN
+                                1
+                            WHEN rs_to_status = 'REQ_FILLED_LOCALLY' THEN
                                 1
                             ELSE
                                 0
@@ -121,6 +135,7 @@ FROM (
                     UNION
                     SELECT
                         de_name,
+                        0,
                         0,
                         0,
                         0,

--- a/sql/report_queries/requesting_turnaround/turnaround_req_1.sql
+++ b/sql/report_queries/requesting_turnaround/turnaround_req_1.sql
@@ -22,7 +22,9 @@ FROM (
         reshare_derived.req_stats nrs2
     WHERE
         nrs.rs_req_id = nrs2.rs_req_id
-        AND (nrs.rs_to_status = 'REQ_VALIDATED'
+        AND (((nrs.rs_from_status = 'REQ_IDLE'
+                    OR nrs.rs_from_status = 'REQ_INVALID_PATRON')
+                AND nrs.rs_to_status = 'REQ_VALIDATED')
             AND nrs2.rs_from_status = 'REQ_EXPECTS_TO_SUPPLY'
             AND nrs2.rs_to_status = 'REQ_SHIPPED')
         AND nrs.rs_date_created >= (

--- a/sql/report_queries/requesting_turnaround/turnaround_req_3.sql
+++ b/sql/report_queries/requesting_turnaround/turnaround_req_3.sql
@@ -22,7 +22,9 @@ FROM (
         reshare_derived.req_stats nrs2
     WHERE
         nrs.rs_req_id = nrs2.rs_req_id
-        AND (nrs.rs_to_status = 'REQ_VALIDATED'
+        AND (((nrs.rs_from_status = 'REQ_IDLE'
+                    OR nrs.rs_from_status = 'REQ_INVALID_PATRON')
+                AND nrs.rs_to_status = 'REQ_VALIDATED')
             AND nrs2.rs_from_status = 'REQ_SHIPPED'
             AND nrs2.rs_to_status = 'REQ_CHECKED_IN')
         AND nrs.rs_date_created >= (

--- a/sql/report_queries/requesting_turnaround/turnaround_req_4.sql
+++ b/sql/report_queries/requesting_turnaround/turnaround_req_4.sql
@@ -11,7 +11,9 @@ FROM
     reshare_derived.req_stats nrs2
 WHERE
     nrs.rs_req_id = nrs2.rs_req_id
-    AND (nrs.rs_to_status = 'REQ_VALIDATED'
+    AND (((nrs.rs_from_status = 'REQ_IDLE'
+                OR nrs.rs_from_status = 'REQ_INVALID_PATRON')
+            AND nrs.rs_to_status = 'REQ_VALIDATED')
         AND nrs2.rs_from_status = 'REQ_SHIPPED'
         AND nrs2.rs_to_status = 'REQ_CHECKED_IN')
     AND (nrs2.rs_date_created - nrs.rs_date_created) < '2 days'

--- a/sql/report_queries/requesting_turnaround/turnaround_req_5.sql
+++ b/sql/report_queries/requesting_turnaround/turnaround_req_5.sql
@@ -11,7 +11,9 @@ FROM
     reshare_derived.req_stats nrs2
 WHERE
     nrs.rs_req_id = nrs2.rs_req_id
-    AND (nrs.rs_to_status = 'REQ_VALIDATED'
+    AND (((nrs.rs_from_status = 'REQ_IDLE'
+                OR nrs.rs_from_status = 'REQ_INVALID_PATRON')
+            AND nrs.rs_to_status = 'REQ_VALIDATED')
         AND nrs2.rs_from_status = 'REQ_SHIPPED'
         AND nrs2.rs_to_status = 'REQ_CHECKED_IN')
     AND ((nrs2.rs_date_created - nrs.rs_date_created) < '3 days'

--- a/sql/report_queries/requesting_turnaround/turnaround_req_6.sql
+++ b/sql/report_queries/requesting_turnaround/turnaround_req_6.sql
@@ -11,7 +11,9 @@ FROM
     reshare_derived.req_stats nrs2
 WHERE
     nrs.rs_req_id = nrs2.rs_req_id
-    AND (nrs.rs_to_status = 'REQ_VALIDATED'
+    AND (((nrs.rs_from_status = 'REQ_IDLE'
+                OR nrs.rs_from_status = 'REQ_INVALID_PATRON')
+            AND nrs.rs_to_status = 'REQ_VALIDATED')
         AND nrs2.rs_from_status = 'REQ_SHIPPED'
         AND nrs2.rs_to_status = 'REQ_CHECKED_IN')
     AND (nrs2.rs_date_created - nrs.rs_date_created) > '3 days'


### PR DESCRIPTION
- Bring __start value into derived tables
- Use current audit table instead of historical audit table
- Separate locally filled requests in core requesting report
- Filter out improperly configured PALCI locations (Bobst and South Charleston)